### PR TITLE
fix pytz version dependency error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
 	url="https://github.com/aj3sh/nepali",
 	packages=setuptools.find_packages(),
 	install_requires=[
-		'pytz==2018.9'
+		'pytz'
 	],
 	classifiers=[
 


### PR DESCRIPTION
Error: nepali 0.4.1 requires pytz==2018.9, but you'll have pytz 2019.3 which is incompatible.