### PR TITLE
docs: fix typo in function docstring

### DIFF
--- a/nepali/phone_number.py
+++ b/nepali/phone_number.py
@@ -37,10 +37,10 @@ def is_mobile_number(number: str) -> bool:
 
 def is_landline_number(number: str) -> bool:
     """
-    Returns True is the input number is mobile number.
+    Returns True is the input number is landline number.
 
-    >>> is_mobile = is_mobile_number(number)
-    >>> if is_mobile:
+    >>> is_landline = is_landline_number(number)
+    >>> if is_landline:
     >>>     ...
     """
     try:
@@ -167,7 +167,7 @@ def _parse_landline_number(number) -> dict:
     {
         "type": "Landline",
         "number": "98XXXXXXXX",
-        "operator": <Operator>
+        "area_code": <AreaCode>
     }
     """
     number = get_exact_number(number)

--- a/nepali/phone_number.py
+++ b/nepali/phone_number.py
@@ -162,7 +162,7 @@ def _get_area_code(number) -> str:
 
 def _parse_landline_number(number) -> dict:
     """
-    Parse and returns mobile number details.
+    Parse and returns landline number details.
     :return:
     {
         "type": "Landline",


### PR DESCRIPTION
The docstring in  function _parse_landline_number suggested that it parses phone numbers, changed that to landline-number