### PR TITLE
replace reused docstrings in landline number handling functions. 

### DIFF
--- a/nepali/phone_number.py
+++ b/nepali/phone_number.py
@@ -37,10 +37,10 @@ def is_mobile_number(number: str) -> bool:
 
 def is_landline_number(number: str) -> bool:
     """
-    Returns True is the input number is mobile number.
+    Returns True is the input number is landline number.
 
-    >>> is_mobile = is_mobile_number(number)
-    >>> if is_mobile:
+    >>> is_landline = is_landline_number(number)
+    >>> if is_landline:
     >>>     ...
     """
     try:
@@ -167,7 +167,7 @@ def _parse_landline_number(number) -> dict:
     {
         "type": "Landline",
         "number": "98XXXXXXXX",
-        "operator": <Operator>
+        "area_code": <AreaCode>
     }
     """
     number = get_exact_number(number)

--- a/nepali/phone_number.py
+++ b/nepali/phone_number.py
@@ -162,7 +162,7 @@ def _get_area_code(number) -> str:
 
 def _parse_landline_number(number) -> dict:
     """
-    Parse and returns mobile number details.
+    Parse and returns landline number details.
     :return:
     {
         "type": "Landline",


### PR DESCRIPTION
## Description
the docstrings used in landline functions are reused from their counterparts of mobiel number handling functions, fixed that and , since the _parse_landline_number function was not returning Operator but area_code, i renamed that part too

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [X] Documentation update
- [ ] Refactor
- [ ] Other (please specify)

## Checklist
- [x] I have used pre-commit hooks.
- [x] I have added/updated the necessary documentation on `README.md`.
- [x] I have updated `CHANGELOG.md` for the significant changes.
- [x] I have added appropriate test cases (if applicable) to ensure the changes are functioning correctly.
- [x] My pull request has a clear title and description.
