### PR TITLE
This pr moves operater prefixes to a separate lookup table and also adds 976 to ntc numbers

### DIFF
--- a/nepali/phone_number.py
+++ b/nepali/phone_number.py
@@ -207,7 +207,7 @@ def _get_operator(number: str) -> Operator | None:
     starting_number = number[:3]
 
     # NTC
-    if starting_number in ["984", "985", "986", "974", "975"]:
+    if starting_number in ["984", "985", "986", "974", "975", "976"]:
         return Operator.NEPAL_TELECOM
 
     # NCELL

--- a/nepali/phone_number.py
+++ b/nepali/phone_number.py
@@ -21,6 +21,15 @@ class Operator(Enum):
         return f"<Operator: {self.value}>"
 
 
+_OPERATOR_PREFIXES = {
+    Operator.NEPAL_TELECOM: ["984", "985", "986", "974", "975", "976"],
+    Operator.NCELL: ["980", "981", "982"],
+    Operator.SMART_CELL: ["961", "962", "988"],
+    Operator.UTL: ["972"],
+    Operator.HELLO_MOBILE: ["963"],
+}
+
+
 class Area(Enum):
     # Koshi Province
     BHOJPUR = ("Bhojpur", "029")
@@ -205,27 +214,9 @@ def _get_operator(number: str) -> Operator | None:
     NOTE: The number should be 10digit mobile number.
     """
     starting_number = number[:3]
-
-    # NTC
-    if starting_number in ["984", "985", "986", "974", "975", "976"]:
-        return Operator.NEPAL_TELECOM
-
-    # NCELL
-    if starting_number in ["980", "981", "982"]:
-        return Operator.NCELL
-
-    # Smart Cell
-    if starting_number in ["961", "962", "988"]:
-        return Operator.SMART_CELL
-
-    # UTL
-    if starting_number == "972":
-        return Operator.UTL
-
-    # Hello Mobile
-    if starting_number == "963":
-        return Operator.HELLO_MOBILE
-
+    for operator, prefixes in _OPERATOR_PREFIXES.items():
+        if starting_number in prefixes:
+            return operator
     return None
 
 


### PR DESCRIPTION
## Description
-  move hardcoded operator initials from `_get_operator()` function to `_OPERATOR_PREFIXES:dict`, 
- new ntc numbers start from 976, this pull request adds it in the ntc prefixes list in _get_operator() function. 

## Related Issues
closes #91 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [X] Refactor
- [ ] Other (please specify)

## Checklist

- [x] I have used pre-commit hooks.
- [x] I have added/updated the necessary documentation on `README.md`.
- [x] I have updated `CHANGELOG.md` for the significant changes.
- [x] I have added appropriate test cases (if applicable) to ensure the changes are functioning correctly.
- [x] My pull request has a clear title and description.

By submitting this pull request, I confirm that I have read and complied with the contribution guidelines of this project.
